### PR TITLE
Fix file walker, include day 10, walk from 1 to 25

### DIFF
--- a/src/advent_of_clerk/index.clj
+++ b/src/advent_of_clerk/index.clj
@@ -17,11 +17,12 @@
   []
   (into []
         (keep (fn [day]
-                (let [f (fs/file "src" "advent_of_clerk" (format "day_%s.clj" (cond->> day (<= day 10) (str "0"))))]
+                (let [f (fs/file "src" "advent_of_clerk" (format "day_%s.clj" (cond->> day
+                                                                                (< day 10) (str "0"))))]
                   (when (and (.exists f)
                              (< 3 (count (str/split-lines (slurp f)))))
                     (str f)))))
-        (range 25)))
+        (range 1 26)))
 
 
 #_(build-paths)


### PR DESCRIPTION
Fund this bug while generating with `nextjournal.clerk/build!`
Fix alllows:
- Allow `day_10.clj` to be processed, render is `day_010.clj` now
- Include day 25 to list of days